### PR TITLE
include external files in setup.hql

### DIFF
--- a/src/main/java/com/spotify/beetest/TestCase.java
+++ b/src/main/java/com/spotify/beetest/TestCase.java
@@ -10,6 +10,27 @@ import java.util.List;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.lang3.text.StrLookup;
+
+
+class ExternalFilesSubstitutor {
+    public static final String replace(final String source) {
+        StrSubstitutor strSubstitutor = new StrSubstitutor(
+                new StrLookup<Object>() {
+                    @Override
+                    public String lookup(final String key) {
+                        try {
+                            return Utils.readFile(StringUtils.trim(key));
+                        } catch (IOException e) {
+                            return "";
+                        }
+                    }
+                }, "<%", "%>", '$');
+        return strSubstitutor.replace(source);
+    }
+}
+
 
 public final class TestCase {
 
@@ -143,6 +164,8 @@ public final class TestCase {
         String query = (setupQueryFilename != null
                 ? Utils.readFile(setupQueryFilename) : "");
 
+        // include external files in setup.hql
+        query = ExternalFilesSubstitutor.replace(query);
         // final query
         return StringUtils.join(databaseQuery, tableDdl, query,
                 getTestedQuery(BEETEST_TEST_OUTPUT_TABLE, BEETEST_TEST_OUTPUT_DIRECTORY, selectQueryFilename));

--- a/src/main/resources/test/includetest.properties
+++ b/src/main/resources/test/includetest.properties
@@ -1,0 +1,2 @@
+sp=src/main/resources/test/setup2.hql
+st=src/main/resources/test/query1.hql

--- a/src/main/resources/test/setup2.hql
+++ b/src/main/resources/test/setup2.hql
@@ -1,0 +1,1 @@
+<% src/main/resources/test/setup1.hql %>

--- a/src/test/java/com/spotify/beetest/TestCaseTest.java
+++ b/src/test/java/com/spotify/beetest/TestCaseTest.java
@@ -72,4 +72,17 @@ public class TestCaseTest {
 
         assertEquals(query, expected);
     }
+
+    @Test
+    public void testIncludeFile() throws IOException {
+        String query = new TestCase(resourcesDir + "/test/includetest.properties").getBeeTestQuery();
+
+        String expected = "CREATE DATABASE IF NOT EXISTS beetest;\n"
+                + "USE beetest;\n"
+                + "CREATE TABLE words(word STRING, length INT)\n"
+                + "ROW FORMAT DELIMITED FIELDS TERMINATED BY '\\t'\n"
+                + "STORED AS TEXTFILE;\n";
+
+        assertEquals(expected, query.substring(0, expected.length()));
+    };
 }


### PR DESCRIPTION
support for including common files in setup.hql, eg tables schema or queries which are tested
