### PR TITLE
(1) Updated README to point to the correct version of Hive (2) Update…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Beetest
 =======
 
 Beetest is a simple utility for testing of Apache Hive scripts locally for non-Java developers.
-Beetest has been tested on Hadoop 2.2.0 (YARN) and Hive 0.12.0.
+Beetest has been tested on Hadoop 2.2.0 (YARN) and Hive 1.2.1.
 
 Motivation
 ----------

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	<hadoop.version>2.2.0</hadoop.version>
+    	<hive.version>1.2.1</hive.version>
     </properties>
 
     <dependencies>
@@ -44,19 +46,19 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>2.2.0</version>
+            <version>${hadoop.version}</version>
         </dependency>
 
 	<dependency>
     	    <groupId>org.apache.hadoop</groupId>
     	    <artifactId>hadoop-hdfs</artifactId>
-    	    <version>2.2.0</version>
+    	    <version>${hadoop.version}</version>
 	</dependency>
 
         <dependency>
     	    <groupId>org.apache.hadoop</groupId>
     	    <artifactId>hadoop-hdfs</artifactId>
-    	    <version>2.2.0</version>
+    	    <version>${hadoop.version}</version>
     	    <classifier>tests</classifier>
 	</dependency>
 
@@ -75,13 +77,13 @@
 	<dependency>
     	    <groupId>org.apache.hadoop</groupId>
     	    <artifactId>hadoop-minicluster</artifactId>
-    	    <version>2.2.0</version>
+    	    <version>${hadoop.version}</version>
 	</dependency>
 
 	<dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>2.2.0</version>
+            <version>${hadoop.version}</version>
         </dependency>
 
 	<dependency>
@@ -105,19 +107,19 @@
 	<dependency>
     	    <groupId>org.apache.hive</groupId>
     	    <artifactId>hive-common</artifactId>
-    	    <version>1.2.1</version>
+    	    <version>${hive.version}</version>
 	</dependency>
 
 	<dependency>
     	   <groupId>org.apache.hive</groupId>
     	   <artifactId>hive-service</artifactId>
-    	   <version>1.2.1</version>
+    	   <version>${hive.version}</version>
 	</dependency>
 
 	<dependency>
     	   <groupId>org.apache.hive</groupId>
     	   <artifactId>hive-metastore</artifactId>
-    	   <version>1.2.1</version>
+    	   <version>${hive.version}</version>
 	</dependency>
 
 	<dependency>
@@ -129,7 +131,7 @@
         <dependency>
      	   <groupId>org.apache.hive</groupId>
      	   <artifactId>hive-jdbc</artifactId>
-     	   <version>1.2.1</version>
+     	   <version>${hive.version}</version>
  	</dependency>    
             
     </dependencies>


### PR DESCRIPTION
…d pom file to use hadoop.version and hive.version variables instead of hand jamming versions everywhere